### PR TITLE
Add additional custom argument support

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,6 +56,7 @@ exports.config = {
 * `issue(value)` – assign issue id to test
 * `testId(value)` – assign TMS test id to test
 * `addEnvironment(name, value)` – save environment value
+* `addArgument(name, value)` - add additional argument to test
 * `createAttachment(name, content, [type])` – save attachment to test.
     * `name` (*String*) - attachment name.
     * `content` – attachment content.

--- a/lib/reporter.js
+++ b/lib/reporter.js
@@ -377,9 +377,9 @@ class AllureReporter extends events.EventEmitter {
         test.addParameter('argument', paramName, paramValue)
     }
 
-    allureAddArgument ({ cid, argName, argValue }) {
+    allureAddArgument ({ cid, name, value }) {
         const test = this.getAllure(cid).getCurrentTest()
-        test.addParameter('argument', argName, argValue)
+        test.addParameter('argument', name, value)
     }
 
     static createStep (title, body, bodyLabel = 'attachment', status = PASSED) {

--- a/lib/reporter.js
+++ b/lib/reporter.js
@@ -67,6 +67,7 @@ class AllureReporter extends events.EventEmitter {
         this.on('allure:severity', ::this.allureSeverity)
         this.on('allure:issue', ::this.allureIssue)
         this.on('allure:testId', ::this.allureTestId)
+        this.on('allure:addArgument', ::this.allureAddArgument)
     }
 
     suiteStart (suite) {
@@ -376,6 +377,11 @@ class AllureReporter extends events.EventEmitter {
         test.addParameter('argument', paramName, paramValue)
     }
 
+    allureAddArgument ({ cid, argName, argValue }) {
+        const test = this.getAllure(cid).getCurrentTest()
+        test.addParameter('argument', argName, argValue)
+    }
+
     static createStep (title, body, bodyLabel = 'attachment', status = PASSED) {
         const step = {
             title,
@@ -416,6 +422,10 @@ class AllureReporter extends events.EventEmitter {
 
     static testId (testId) {
         AllureReporter.tellReporter('allure:testId', { testId })
+    }
+
+    static addArgument (name, value) {
+        AllureReporter.tellReporter('allure:addArgument', { name, value })
     }
 
     static tellReporter (event, msg = {}) {

--- a/test/fixtures/specs/argument.js
+++ b/test/fixtures/specs/argument.js
@@ -1,0 +1,14 @@
+'use strict'
+
+const reporter = require('./../../../build/reporter')
+
+describe('Suite with custom argument', () => {
+    console.log('Running suite')
+    it('Test #1', () => {
+        reporter.addArgument('os', 'osx')
+    })
+
+    it('Test #1', () => {
+        reporter.addArgument('os', 'windows')
+    })
+})

--- a/test/specs/argument.js
+++ b/test/specs/argument.js
@@ -1,0 +1,37 @@
+import { expect } from 'chai'
+import { clean, runMocha } from '../helper'
+
+describe('Add argument', () => {
+    beforeEach(clean)
+
+    it('should add argument to test cases', () => {
+        return runMocha(['argument']).then(results => {
+            expect(results).to.have.lengthOf(1)
+            const result = results[0]
+
+            expect(result('ns2\\:test-suite > name').text()).to.be.equal(
+                'Suite with custom argument'
+            )
+            expect(
+                result('test-case > name')
+                    .eq(0)
+                    .text()
+            ).to.be.equal('Test #1')
+            expect(
+                result('test-case > name')
+                    .eq(1)
+                    .text()
+            ).to.be.equal('Test #1')
+            expect(
+                result('test-case parameter[name="os"]')
+                    .eq(0)
+                    .attr('value')
+            ).to.be.equal('osx')
+            expect(
+                result('test-case parameter[name="os"]')
+                    .eq(1)
+                    .attr('value')
+            ).to.be.equal('windows')
+        })
+    })
+})


### PR DESCRIPTION
This adds ability to add additional custom argument to the test like OS or screen resolution to prevent merging separate runs as one in allure report.
#142 